### PR TITLE
fix(src/envoy-grpc-request-params.ts): Remove use of grpc default export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "envoy-node",
-  "version": "1.6.0-development",
+  "version": "1.9.0-development",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2696,7 +2696,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "conventional-changelog-angular": {
       "version": "5.0.2",
@@ -3774,7 +3775,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3795,12 +3797,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3815,17 +3819,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3942,7 +3949,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3954,6 +3962,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3968,6 +3977,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3975,12 +3985,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3999,6 +4011,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4079,7 +4092,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4091,6 +4105,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4176,7 +4191,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4212,6 +4228,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4231,6 +4248,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4274,12 +4292,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/src/envoy-grpc-request-params.ts
+++ b/src/envoy-grpc-request-params.ts
@@ -1,4 +1,4 @@
-import grpc from "grpc";
+import { Metadata } from "grpc";
 
 import EnvoyRequestParams, {
   X_ENVOY_MAX_RETRIES,
@@ -54,7 +54,7 @@ export interface EnvoyGrpcRequestInit {
  * @internal
  */
 export function httpHeader2Metadata(httpHeader: HttpHeader) {
-  const metadata = new grpc.Metadata();
+  const metadata = new Metadata();
   for (const [key, value] of Object.entries(httpHeader)) {
     if (Array.isArray(value)) {
       value.forEach(v => metadata.add(key, v));
@@ -97,7 +97,7 @@ export default class EnvoyGrpcRequestParams extends EnvoyRequestParams {
   /**
    * assemble the request headers for setting retry.
    */
-  assembleRequestMeta(): grpc.Metadata {
+  assembleRequestMeta(): Metadata {
     const metadata = httpHeader2Metadata({
       ...this.context.assembleTracingHeader(),
       ...this.customHeaders


### PR DESCRIPTION
I found that when trying to compile a module referencing this one with Typescript 3.2.4, it
complained that grpc has no default export. So I modified the import to use the actual type instead
in src/envoy-grpc-request-params.ts.